### PR TITLE
[exporter/prometheusremotewrite] only append colliding attributes values if they are different

### DIFF
--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -141,7 +141,10 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 	for _, label := range labels {
 		finalKey := prometheustranslator.NormalizeLabel(label.Name)
 		if existingValue, alreadyExists := l[finalKey]; alreadyExists {
-			l[finalKey] = existingValue + ";" + label.Value
+			// Only append to existing value if the new value is different
+			if existingValue != label.Value {
+				l[finalKey] = existingValue + ";" + label.Value
+			}
 		} else {
 			l[finalKey] = label.Value
 		}

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -350,6 +350,14 @@ func Test_createLabelSet(t *testing.T) {
 			getPromLabels(collidingSanitized, value11+";"+value12, label31, value31, label32, value32),
 		},
 		{
+			"existing_attribute_value_is_the_same_as_the_new_label_value",
+			pcommon.NewResource(),
+			lbsCollidingSameValue,
+			nil,
+			[]string{label31, value31, label32, value32},
+			getPromLabels(collidingSanitized, value11, label31, value31, label32, value32),
+		},
+		{
 			"sanitize_labels_starts_with_underscore",
 			pcommon.NewResource(),
 			lbs3,

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -58,10 +58,11 @@ var (
 	floatVal1       = 1.0
 	floatVal2       = 2.0
 
-	lbs1         = getAttributes(label11, value11, label12, value12)
-	lbs3         = getAttributes(label11, value11, label12, value12, label51, value51)
-	lbs1Dirty    = getAttributes(label11+dirty1, value11, dirty2+label12, value12)
-	lbsColliding = getAttributes(colliding1, value11, colliding2, value12)
+	lbs1                  = getAttributes(label11, value11, label12, value12)
+	lbs3                  = getAttributes(label11, value11, label12, value12, label51, value51)
+	lbs1Dirty             = getAttributes(label11+dirty1, value11, dirty2+label12, value12)
+	lbsColliding          = getAttributes(colliding1, value11, colliding2, value12)
+	lbsCollidingSameValue = getAttributes(colliding1, value11, colliding2, value11)
 
 	exlbs1 = map[string]string{label41: value41}
 	exlbs2 = map[string]string{label11: value41}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

While translating two OTel attributes into Prometheus Label, if two attributes being the same with the same value, this change avoids the situation of duplicate values separated by semicolon.

Example:
- "bar.one": "foo"
- "bar/one": "foo"

The above two attributes when translated to Prometheus label would become
- Before this change
    - "bar_one": "foo;foo"
- After the change
    - "bar_one": "foo"

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35896

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- unit test added

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
